### PR TITLE
Specify eth0 in ifconfig command

### DIFF
--- a/xming-start-for-wsl2.ps1
+++ b/xming-start-for-wsl2.ps1
@@ -1,6 +1,6 @@
 function Get-WSL2IPAddress{
     param([string]$distro)
-    $ifconfig_cmd = @("run", "ifconfig");
+    $ifconfig_cmd = @("run", "ifconfig eth0");
     try {
         $cmd_output = & $distro $ifconfig_cmd
     } 


### PR DESCRIPTION
Specifying the interface in the ifconfig command ensures that the script doesn't accidentally retrieve the IP address of an interface local to the WSL instance, like docker0.